### PR TITLE
Correct clip plane with new offsets in world-portals

### DIFF
--- a/lua/star_trek/portals/cl_portals.lua
+++ b/lua/star_trek/portals/cl_portals.lua
@@ -132,6 +132,13 @@ hook.Add("PostDrawSkyBox", "Testing", function()
 	if wp and wp.drawing and IsValid(wp.drawingent) then
 		local ent = wp.drawingent
 		local exitPortal = ent:GetExit()
-		render.PushCustomClipPlane( exitPortal:GetForward(), exitPortal:GetForward():Dot( exitPortal:GetPos() - exitPortal:GetForward() * 0.5 ) )
+		local fwd = exitPortal:GetForward()
+		fwd:Rotate(exitPortal:GetExitAngOffset())
+		local posOffset =  exitPortal:GetExitPosOffset()
+		if IsValid(exitPortal:GetParent()) then
+			posOffset:Rotate(exitPortal:GetParent():GetAngles())
+		end
+		local pos = exitPortal:GetPos() + posOffset
+		render.PushCustomClipPlane( fwd, fwd:Dot( pos - fwd * 0.5 ) )
 	end
 end)


### PR DESCRIPTION
After the addition of Get/Set ExitPosOffset/AngOffset the code here was not taking it into account and causing weird clipping when the new offsets were used. They are now taken into account

I've also slightly optimised the 3 calls of `exitPortal:GetForward()` into 1 which should make up for the very slight perf hit we'll get from calculating the offsets now