### PR TITLE
[BUG FIX] Error while undoing a prop while it is in an animation in holodeck

### DIFF
--- a/lua/star_trek/holodeck/sv_holomatter.lua
+++ b/lua/star_trek/holodeck/sv_holomatter.lua
@@ -41,6 +41,7 @@ function Star_Trek.Holodeck:Disintegrate(ent, inverted)
 
 	local timerName = "Star_Trek.Holodeck.Disintegrate." .. ent:EntIndex()
 	timer.Create(timerName, 1, 1, function()
+		if not IsValid(ent) then return end
 		if inverted then
 			ent:SetRenderMode(oldMode)
 			ent:SetColor(color)


### PR DESCRIPTION
**ERROR:** If you are in the holodeck and spawn a prop and undo it before it finishes the animation an error pops up:

![image](https://user-images.githubusercontent.com/99217547/184946086-b845640b-be54-42e7-87e9-972dd928c383.png)

**FIX:** Check if the entity is valid otherwise return