### PR TITLE
[BUG FIX] Fix weird word order in personal logs

### DIFF
--- a/lua/star_trek/lcars/windows/text_entry/cl_init.lua
+++ b/lua/star_trek/lcars/windows/text_entry/cl_init.lua
@@ -64,7 +64,7 @@ function SELF:CheckLine(words, subLines)
 	end
 
 	if newLinePrev ~= newLine then
-		table.insert(words, lastWord)
+		table.insert(words, 1, lastWord)
 	end
 	table.insert(subLines, string.sub(newLinePrev, 1, #newLinePrev - 1))
 


### PR DESCRIPTION
Fix the weird word order when you write a long line without any line breaks.