### PR TITLE
Add scanData.Weapons for players

### DIFF
--- a/lua/star_trek/sensors/sv_sensors.lua
+++ b/lua/star_trek/sensors/sv_sensors.lua
@@ -122,7 +122,7 @@ function Star_Trek.Sensors:ScanEntity(ent)
 	end
 
 	-- Check for Scripted Entities
-	if ent:IsScripted() then
+	if ent:IsScripted() and not ent:IsWeapon() then
 		local name = ent.PrintName
 		if isstring(name) and name ~= "" then
 			scanData.Name = name

--- a/lua/star_trek/sensors/sv_sensors.lua
+++ b/lua/star_trek/sensors/sv_sensors.lua
@@ -169,32 +169,20 @@ end)
 
 hook.Add("Star_Trek.Sensors.ScanPlayer", "Sensors.CheckWeapons", function(ent, scanData)
 	scanData.Weapons = {}
-	local blacklist = {"Physgun", "ToolGun", "GravityGun"}
+	local blacklist = {"Physics Gun", "#GMOD_ToolGun", "Gravity Gun"}
 	for _, weapon in pairs(ent:GetWeapons()) do
-		local skip = false
-		local name = weapon:GetPrintName()
-		if string.StartWith(name, "#HL2_") then name = name:sub(6) end
-		if string.StartWith(name, "#GMOD_") then name = name:sub(7) end
-
-		-- Check if weapon is in the blacklist
-		for _, value in ipairs(blacklist) do
-			if name == value then
-				skip = true
-				break
+		local success, wepScanData = Star_Trek.Sensors:ScanEntity(weapon)
+		if success then
+			-- Check if weapon is in the blacklist
+			local skip = false
+			for _, value in ipairs(blacklist) do
+				if wepScanData.Name == value then
+					skip = true
+					break
+				end
 			end
-		end
-		if skip then continue end
 
-		local curWeapon = scanData.Weapons[table.insert(scanData.Weapons, {})]
-		if weapon:IsScripted() and name == "Scripted Weapon" or name == "" then
-			curWeapon.Name = "Unknown Weapon"
-		else
-			curWeapon.Name = name
-		end
-		if weapon.HoloMatter then
-			curWeapon.Holomatter = true
-		else
-			curWeapon.Holomatter = false
+			if not skip then table.insert(scanData.Weapons, wepScanData) end
 		end
 	end
 end)

--- a/lua/star_trek/sensors/sv_sensors.lua
+++ b/lua/star_trek/sensors/sv_sensors.lua
@@ -167,6 +167,38 @@ hook.Add("Star_Trek.Sensors.ScanPlayer", "Sensors.CheckArmor", function(ent, sca
 	end
 end)
 
+hook.Add("Star_Trek.Sensors.ScanPlayer", "Sensors.CheckWeapons", function(ent, scanData)
+	scanData.Weapons = {}
+	local blacklist = {"Physgun", "ToolGun", "GravityGun"}
+	for _, weapon in pairs(ent:GetWeapons()) do
+		local skip = false
+		local name = weapon:GetPrintName()
+		if string.StartWith(name, "#HL2_") then name = name:sub(6) end
+		if string.StartWith(name, "#GMOD_") then name = name:sub(7) end
+
+		-- Check if weapon is in the blacklist
+		for _, value in ipairs(blacklist) do
+			if name == value then
+				skip = true
+				break
+			end
+		end
+		if skip then continue end
+
+		local curWeapon = scanData.Weapons[table.insert(scanData.Weapons, {})]
+		if weapon:IsScripted() and name == "Scripted Weapon" or name == "" then
+			curWeapon.Name = "Unknown Weapon"
+		else
+			curWeapon.Name = name
+		end
+		if weapon.HoloMatter then
+			curWeapon.Holomatter = true
+		else
+			curWeapon.Holomatter = false
+		end
+	end
+end)
+
 -- Record Entity Physics Object.
 hook.Add("Star_Trek.Sensors.ScanEntity", "Sensors.CheckMass", function(ent, scanData)
 	local physCount = ent:GetPhysicsObjectCount()


### PR DESCRIPTION
Add scanData.Weapons for players.

It stores the names and if it is holomatter (more can easily be added)
`{{Name="Crowbar",Holomatter=false,},{Name="Pistol",Holomatter=false,},{Name="SMG1",Holomatter=false,}, ect`

Also has a blacklist, so the scan will not show the Toolgun, Physgun or GravityGun (more can easily be added)