### PR TITLE
Fixing issue caused by changes made on pull

### DIFF
--- a/lua/star_trek/transporter/interfaces/transporter/init.lua
+++ b/lua/star_trek/transporter/interfaces/transporter/init.lua
@@ -164,15 +164,23 @@ function Star_Trek.LCARS:OpenTransporterMenu()
 	Star_Trek.LCARS:OpenInterface(TRIGGER_PLAYER, CALLER, "transporter")
 end
 
-hook.Add("Star_Trek.Transporter.UpdateBuffer", "Star_Trek.Transporter.BufferWindowUpdate", function(purgedEnt, interfaceEnt)
+hook.Add("Star_Trek.Transporter.UpdateBuffer", "Star_Trek.Transporter.BufferWindowUpdate", function(interfaceEnt)
 	-- Remove the item from the buffer list in the window
 	interfaceData = Star_Trek.LCARS.ActiveInterfaces[interfaceEnt]
 	for _,windowData in pairs(interfaceData.Windows) do
 		if windowData.TitleShort ~= nil and windowData.TitleShort == "Buffer" then
-			buttons = table.Copy(windowData.Buttons)
-			for key, button in pairs (windowData.Buttons) do
-				if button.Data == purgedEnt then
-					table.remove(buttons, key)
+			buttons = {}
+			for _, button in pairs (windowData.Buttons) do
+				if table.HasValue(Star_Trek.Transporter.Buffer.Entities, button.Data) then
+					table.insert(buttons, button)
+				end
+			end
+			--Updating the colors because to be alternated because they do something weird.
+			for key, val in pairs(buttons) do
+				if key % 2 ~= 0 then
+					val.Color = Star_Trek.LCARS.ColorBlue
+				else 
+					val.Color = Star_Trek.LCARS.ColorLightBlue
 				end
 			end
 			windowData:ClearMainButtons()

--- a/lua/star_trek/transporter/interfaces/transporter/windowUtil.lua
+++ b/lua/star_trek/transporter/interfaces/transporter/windowUtil.lua
@@ -168,7 +168,7 @@ function SELF:CreateMenuWindow(pos, angle, width, menuTable, hFlip)
 						ent.BufferQuality = 0
 						local success1, scanData = Star_Trek.Sensors:ScanEntity(ent)
 						if success1 then
-							Star_Trek.Logs:AddEntry(self.Ent, ply, "Purging: " .. scanData.Name , Star_Trek.LCARS.ColorRed)
+							Star_Trek.Logs:AddEntry(self.Ent, ply, "PURGING: " .. scanData.Name , Star_Trek.LCARS.ColorRed)
 						end
 					end
 

--- a/lua/star_trek/transporter/sv_transporter.lua
+++ b/lua/star_trek/transporter/sv_transporter.lua
@@ -147,7 +147,6 @@ function Star_Trek.Transporter:ActivateTransporter(interfaceEnt, ply, sourcePatt
 
 				updateBuffer = true
 			end
-
 			local success, scanData = Star_Trek.Sensors:ScanEntity(ent)
 			if success then
 				Star_Trek.Logs:AddEntry(interfaceEnt, ply, "Dematerialising " .. scanData.Name .. "...")
@@ -189,7 +188,6 @@ function Star_Trek.Transporter:ActivateTransporter(interfaceEnt, ply, sourcePatt
 		-- Beam into Buffer
 		table.insert(Star_Trek.Transporter.Buffer.Entities, ent)
 		ent.BufferQuality = 160
-
 		if istable(ent) then
 			Star_Trek.Logs:AddEntry(interfaceEnt, ply, "WARNING: Remote Transporter Request has no target. Aborting!", Star_Trek.LCARS.ColorRed)
 			continue
@@ -203,7 +201,6 @@ function Star_Trek.Transporter:ActivateTransporter(interfaceEnt, ply, sourcePatt
 		end)
 
 		Star_Trek.Logs:AddEntry(interfaceEnt, ply, "WARNING: No Free Target Position Available! Storing in Buffer!", Star_Trek.LCARS.ColorRed)
-
 		if success and scanData.Alive then
 			Star_Trek.Logs:AddEntry(interfaceEnt, ply, "WARNING: " .. scanData.Name .. " has been transported to the Buffer!", Star_Trek.LCARS.ColorRed)
 			local timerName = "Star_Trek.Transporter.BufferAlert." .. interfaceEnt:EntIndex()
@@ -218,8 +215,7 @@ function Star_Trek.Transporter:ActivateTransporter(interfaceEnt, ply, sourcePatt
 			end)
 		end
 	end
-
 	if updateBuffer then
-		hook.Run("Star_Trek.Transporter.UpdateBuffer", ent, interfaceEnt)
+		hook.Run("Star_Trek.Transporter.UpdateBuffer", interfaceEnt)
 	end
 end

--- a/lua/star_trek/transporter/sv_transporter_cycle.lua
+++ b/lua/star_trek/transporter/sv_transporter_cycle.lua
@@ -216,7 +216,7 @@ timer.Create("Star_Trek.Transporter.BufferThink", 1, 0, function()
 	if #removeFromBuffer > 0 then
 		for _, interfaceData in pairs(Star_Trek.LCARS.ActiveInterfaces) do
 			if isstring(interfaceData.CycleClass) then
-				hook.Run("Star_Trek.Transporter.UpdateBuffer", ent, interfaceData.Ent)
+				hook.Run("Star_Trek.Transporter.UpdateBuffer", interfaceData.Ent)
 			end
 		end
 	end


### PR DESCRIPTION
Oni updated the hook to only be called once on transport rather than for every entity. Doing so moved the hook out of the scope of the entity, and it moving it into the scope would just cause it to continue to fire per entity. Changed the way the hook works so now it doesn't remove the button based on an input entity, it just compares the existing button list with the entities in the buffer to see if the entity is actually still in there.