### PR TITLE
Fixed issue where buffer loop wasnt continuing

### DIFF
--- a/lua/star_trek/transporter/sv_transporter_cycle.lua
+++ b/lua/star_trek/transporter/sv_transporter_cycle.lua
@@ -195,6 +195,7 @@ timer.Create("Star_Trek.Transporter.BufferThink", 1, 0, function()
 			else
 				SafeRemoveEntity(ent)
 			end
+			continue
 		end
 
 		ent.BufferQuality = ent.BufferQuality - 1


### PR DESCRIPTION
For some reason there was no continue statement after an ent was removed from the buffer if its quality is 0, it would still try and decrease its quality.