### PR TITLE
LCARS use prevention when dead

### DIFF
--- a/lua/star_trek/lcars/cl_lcars_interfaces.lua
+++ b/lua/star_trek/lcars/cl_lcars_interfaces.lua
@@ -154,7 +154,7 @@ end)
 function Star_Trek.LCARS:PlayerButtonDown(ply, button)
 	if not ((button == KEY_E and not ply.DisableEButton) or button == MOUSE_LEFT or button == MOUSE_RIGHT) then return end
 
-	if !ply:Alive() then return end
+	if not ply:Alive() then return end
 
 	for id, interface in pairs(Star_Trek.LCARS.ActiveInterfaces) do
 		if not interface.IVis then

--- a/lua/star_trek/lcars/cl_lcars_interfaces.lua
+++ b/lua/star_trek/lcars/cl_lcars_interfaces.lua
@@ -154,6 +154,8 @@ end)
 function Star_Trek.LCARS:PlayerButtonDown(ply, button)
 	if not ((button == KEY_E and not ply.DisableEButton) or button == MOUSE_LEFT or button == MOUSE_RIGHT) then return end
 
+	if !ply:Alive() then return end
+
 	for id, interface in pairs(Star_Trek.LCARS.ActiveInterfaces) do
 		if not interface.IVis then
 			continue

--- a/lua/star_trek/lcars/sv_lcars_interfaces.lua
+++ b/lua/star_trek/lcars/sv_lcars_interfaces.lua
@@ -233,6 +233,8 @@ net.Receive("Star_Trek.LCARS.Pressed", function(len, ply)
 	local windowId = net.ReadInt(32)
 	local buttonId = net.ReadInt(32)
 
+	if not ply:Alive() then return end
+
 	local ent = ents.GetByIndex(id)
 	if not IsValid(ent) then
 		return


### PR DESCRIPTION
Blame Poe.

A singular if statement was required to check if the player is alive. I spent more time downloading DarkRP to get a respawn timer then I did actually fixing the bug.