### PR TITLE
Add transporter hooks

### DIFF
--- a/lua/star_trek/transporter/sv_transporter.lua
+++ b/lua/star_trek/transporter/sv_transporter.lua
@@ -150,6 +150,16 @@ end
 function Star_Trek.Transporter:ActivateTransporter(interfaceEnt, ply, sourcePatterns, targetPatterns, cycleClass, noBuffer, allowWeapons)
 	if not istable(sourcePatterns) then return end
 
+	-- Check if entities should be transported.
+	local newSourcePatterns = {}
+	for _, sourcePattern in pairs(sourcePatterns) do
+		-- Check if the entity should be ignored. If the hook returns true, the entity will be ignored.
+		if not hook.Run("Star_Trek.Transporter.IgnoreTransportEntity", sourcePattern.Ent) then
+			table.insert(newSourcePatterns, sourcePattern)
+		end
+	end
+	sourcePatterns = newSourcePatterns
+
 	Star_Trek.Logs:AddEntry(interfaceEnt, ply, "")
 	Star_Trek.Logs:AddEntry(interfaceEnt, ply, "Initialising Transporter...")
 	Star_Trek.Logs:AddEntry(interfaceEnt, ply, table.Count(sourcePatterns) .. " Pattern Sources Detected.")

--- a/lua/star_trek/transporter/sv_transporter.lua
+++ b/lua/star_trek/transporter/sv_transporter.lua
@@ -150,16 +150,6 @@ end
 function Star_Trek.Transporter:ActivateTransporter(interfaceEnt, ply, sourcePatterns, targetPatterns, cycleClass, noBuffer, allowWeapons)
 	if not istable(sourcePatterns) then return end
 
-	-- Check if entities should be transported.
-	local newSourcePatterns = {}
-	for _, sourcePattern in pairs(sourcePatterns) do
-		-- Check if the entity should be ignored. If the hook returns true, the entity will be ignored.
-		if not hook.Run("Star_Trek.Transporter.IgnoreTransportEntity", sourcePattern.Ent) then
-			table.insert(newSourcePatterns, sourcePattern)
-		end
-	end
-	sourcePatterns = newSourcePatterns
-
 	Star_Trek.Logs:AddEntry(interfaceEnt, ply, "")
 	Star_Trek.Logs:AddEntry(interfaceEnt, ply, "Initialising Transporter...")
 	Star_Trek.Logs:AddEntry(interfaceEnt, ply, table.Count(sourcePatterns) .. " Pattern Sources Detected.")

--- a/lua/star_trek/transporter/sv_transporter_interference.lua
+++ b/lua/star_trek/transporter/sv_transporter_interference.lua
@@ -16,14 +16,15 @@
 -- Transporter Interference | Server --
 ---------------------------------------
 
-Star_Trek.Transporter.Interferences = Star_Trek.Transporter.Interferences or {} 
+Star_Trek.Transporter.Interferences = Star_Trek.Transporter.Interferences or {}
 
 hook.Add("Star_Trek.Transporter.BlockBeamTo", "Star_Trek.Transporter.CheckForInterfereneces", function(pos)
     for _, data in pairs(Star_Trek.Transporter.Interferences) do
         interferencePos = data.Pos
-        interferenceRadius = data.Radius  
+        interferenceRadius = data.Radius
         distance = pos:Distance(interferencePos)
-        if distance <= interferenceRadius then
+        -- Check dist and if the interference should be ignored. If the hook returns true, then yes.
+        if distance <= interferenceRadius and not hook.Run("Star_Trek.Transporter.IgnoreInterference", data, pos) then
             return true, "Unabled to lock onto target. " .. data.Type .. " Interference detected."
         end
     end


### PR DESCRIPTION
Added some transporter hooks I needed for the pattern enhancer:
1. Hook 1: `hook.Run("Star_Trek.Transporter.IgnoreTransportEntity", sourcePattern.Ent)`
This hook will be called just before entities will be transported. If the hook returns true the entity will be ignored. I needed this to prevent the transportation of active pattern enhancers.

3. Hook 2: `hook.Run("Star_Trek.Transporter.IgnoreInterference", data, pos)`
This hook is called in the `Star_Trek.Transporter.CheckForInterfereneces` hook, so some interferences can be ignored. Needed to make the pattern enhancers actually ignore interference :D

If you have a better way to do these hooks please tell me.