### PR TITLE
Sync external transporter stool when external change

### DIFF
--- a/lua/star_trek/transporter/stools/external_transporter/shared.lua
+++ b/lua/star_trek/transporter/stools/external_transporter/shared.lua
@@ -133,7 +133,7 @@ if SERVER then
 
 		table.insert(Star_Trek.Transporter.Externals, externalData)
 
-		tool:Sync()
+		hook.Run("Star_Trek.Transporter.ExternalsChanged")
 	end)
 
 	util.AddNetworkString("Star_Trek.TransporterTool.Edit")
@@ -147,13 +147,23 @@ if SERVER then
 		local externalData = Star_Trek.Transporter.Externals[id]
 		externalData.Name = name
 
-		tool:Sync()
+		hook.Run("Star_Trek.Transporter.ExternalsChanged")
 	end)
 
 	function TOOL:Deploy()
 		self:Sync()
 	end
 end
+
+hook.Add("Star_Trek.Transporter.ExternalsChanged", "Star_Trek.TransporterTool.ExternalsChanged", function()
+	-- sync every player that has the tool open
+	for _, ply in ipairs(player.GetAll()) do
+		local tool = ply:GetTool()
+		if tool.Mode == "external_transporter" then
+			tool:Sync()
+		end
+	end
+end)
 
 function TOOL:LeftClick(tr)
 	if (CLIENT) then return true end
@@ -169,8 +179,6 @@ function TOOL:LeftClick(tr)
 	net.Send(owner)
 
 	hook.Run("Star_Trek.Transporter.ExternalsChanged")
-
-	self:Sync()
 end
 
 function TOOL:RightClick(tr)
@@ -199,8 +207,6 @@ function TOOL:RightClick(tr)
 
 		hook.Run("Star_Trek.Transporter.ExternalsChanged")
 	end
-
-	self:Sync()
 end
 
 -- Override Closest Transporter Beam Location Name
@@ -228,9 +234,11 @@ function TOOL:Reload(tr)
 		end
 	end
 
+
 	net.Start("Star_Trek.TransporterTool.Edit")
 		net.WriteInt(closest, 32)
 	net.Send(owner)
+	
 end
 
 function TOOL:BuildCPanel()
@@ -244,6 +252,5 @@ function TOOL:BuildCPanel()
 	textEntry = vgui.Create("DTextEntry")
 
 	self:AddItem(textEntry)
-
-
 end
+


### PR DESCRIPTION
When creating the pattern enhancers I noticed that the hook: `"Star_Trek.Transporter.ExternalsChanged"` doesn't do anything and the newly created external location created by the pattern enhancers wouldn't update when the tool was open. So I added this functionality plus added that if two people are creating externals they sync up.
For example, when the pattern enhancers create a new location it will run this hook.

TL;DR
- Externals update when a pattern enhancer creates an external
- when 2 players are using the external transporter stool it will sync

NOTE:
I removed a lot of `tool:Sync` since they are no longer necessary since that is done via the hook now.

As always if you have a better way to do this please tell me :)