### PR TITLE
Fix Viewscreen

### DIFF
--- a/lua/star_trek/portals/entities/linked_portal_window/cl_init.lua
+++ b/lua/star_trek/portals/entities/linked_portal_window/cl_init.lua
@@ -50,7 +50,7 @@ function ENT:Draw()
 		render.SetStencilCompareFunction( STENCIL_ALWAYS )
 	end
 
-	render.SetMaterial( wp.matDummy )
+	render.SetMaterial( wp.matBlack )
 	render.SetColorModulation( 1, 1, 1 )
 
 	-- Draw inverted Quad to have the viewscreen be fully hidden.


### PR DESCRIPTION
On june 7th the doors addon got updated and they renamed the `wp.matDummy` variable:
![image](https://github.com/user-attachments/assets/c60b2b6e-47bc-4a3b-b68d-81bf5c3574b2)
 