### PR TITLE
Don't teleport frozen props in turbolift

### DIFF
--- a/lua/star_trek/turbolift/sv_turbolift.lua
+++ b/lua/star_trek/turbolift/sv_turbolift.lua
@@ -143,6 +143,13 @@ function Star_Trek.Turbolift:GetObjects(liftEntity)
 				continue
 			end
 
+			-- Don't teleport frozen props
+			local physobj = ent:GetPhysicsObject()
+			if IsValid(physobj) and !physobj:IsMotionEnabled() then
+				continue
+			end
+
+
 			if hook.Run("Star_Trek.Turbolift.ExcludeTeleport", liftEntity, ent) then
 				continue
 			end


### PR DESCRIPTION
Don't teleport frozen props in turbolift, I don't see any reason why you would want to. Right now it is teleporting frozen props around the turbolift.